### PR TITLE
feature: underscore reducer and splitter closes #11

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,6 +35,7 @@ Flatten
            used to reduce.
            'tuple': The resulting key will be tuple of the original keys.
            'path': Use `os.path.join` to join keys.
+           'underscore': Use underscores to join keys.
        inverse : bool
            Whether you want invert the resulting key and value.
        enumerate_types : Sequence[type]

--- a/flatten_dict/flatten_dict.py
+++ b/flatten_dict/flatten_dict.py
@@ -31,6 +31,7 @@ def flatten(d, reducer='tuple', inverse=False, enumerate_types=()):
         used to reduce.
         'tuple': The resulting key will be tuple of the original keys.
         'path': Use `os.path.join` to join keys.
+        'underscore': Use underscores to join keys.
     inverse : bool
         Whether you want invert the resulting key and value.
     enumerate_types : Sequence[type]
@@ -101,6 +102,7 @@ def unflatten(d, splitter='tuple', inverse=False):
         used to split.
         'tuple': Use each element in the tuple key as the key of the unflattened dict.
         'path': Use `pathlib.Path.parts` to split keys.
+        'underscore': Use underscores to join keys.
     inverse : bool
         Whether you want to invert the key and value before flattening.
 

--- a/flatten_dict/flatten_dict.py
+++ b/flatten_dict/flatten_dict.py
@@ -2,18 +2,20 @@ from collections import Mapping
 
 import six
 
-from .reducer import tuple_reducer, path_reducer
-from .splitter import tuple_splitter, path_splitter
+from .reducer import tuple_reducer, path_reducer, underscore_reducer
+from .splitter import tuple_splitter, path_splitter, underscore_splitter
 
 
 REDUCER_DICT = {
     'tuple': tuple_reducer,
     'path': path_reducer,
+    'underscore': underscore_reducer,
 }
 
 SPLITTER_DICT = {
     'tuple': tuple_splitter,
     'path': path_splitter,
+    'underscore': underscore_splitter,
 }
 
 

--- a/flatten_dict/reducer.py
+++ b/flatten_dict/reducer.py
@@ -11,3 +11,10 @@ def path_reducer(k1, k2):
         return k2
     else:
         return os.path.join(k1, k2)
+
+
+def underscore_reducer(k1, k2):
+    if k1 is None:
+        return k2
+    else:
+        return k1 + "_" + k2

--- a/flatten_dict/splitter.py
+++ b/flatten_dict/splitter.py
@@ -8,3 +8,8 @@ def tuple_splitter(flat_key):
 def path_splitter(flat_key):
     keys = PurePath(flat_key).parts
     return keys
+
+
+def underscore_splitter(flat_key):
+    keys = tuple(flat_key.split("_"))
+    return keys

--- a/flatten_dict/tests.py
+++ b/flatten_dict/tests.py
@@ -57,6 +57,13 @@ def test_flatten_dict_path():
     assert flatten(normal_dict, reducer='path') == flat_path_dict
 
 
+def test_flatten_dict_underscore():
+    flat_normal_dict_items = six.viewitems(flat_normal_dict)
+    flat_underscore_dict = {os.path.join(
+        *k).replace("/", "_"): v for k, v in flat_normal_dict_items}
+    assert flatten(normal_dict, reducer='underscore') == flat_underscore_dict
+
+
 def test_flatten_dict_inverse_with_duplicated_value():
     dup_val_dict = normal_dict.copy()
     dup_val_dict['a'] = '2.1.1'
@@ -80,6 +87,12 @@ def test_unflatten_dict_with_splitter():
 def test_unflatten_dict_path():
     flat_path_dict = {os.path.join(*k): v for k, v in six.viewitems(flat_normal_dict)}
     assert unflatten(flat_path_dict, splitter='path') == normal_dict
+
+
+def test_unflatten_dict_underscore():
+    flat_underscore_dict = {os.path.join(
+        *k).replace("/", "_"): v for k, v in six.viewitems(flat_normal_dict)}
+    assert unflatten(flat_underscore_dict, splitter='underscore') == normal_dict
 
 
 def test_unflatten_dict_inverse_with_duplicated_value():
@@ -128,6 +141,12 @@ def test_flatten_dict_with_list_path():
     assert flatten(dict_with_list, reducer='path') == flat_path_dict
 
 
+def test_flatten_dict_with_list_underscore():
+    flat_underscore_dict = {os.path.join(
+        *k).replace("/", "_"): v for k, v in six.viewitems(flat_dict_with_list)}
+    assert flatten(dict_with_list, reducer='underscore') == flat_underscore_dict
+
+
 def test_unflatten_dict_with_list():
     assert unflatten(flat_dict_with_list) == dict_with_list
 
@@ -139,6 +158,12 @@ def test_unflatten_dict_with_list_with_splitter():
 def test_unflatten_dict_with_list_path():
     flat_path_dict = {os.path.join(*k): v for k, v in six.viewitems(flat_dict_with_list)}
     assert unflatten(flat_path_dict, splitter='path') == dict_with_list
+
+
+def test_unflatten_dict_with_list_underscore():
+    flat_underscore_dict = {os.path.join(
+        *k).replace("/", "_"): v for k, v in six.viewitems(flat_dict_with_list)}
+    assert unflatten(flat_underscore_dict, splitter='underscore') == dict_with_list
 
 
 flat_dict_with_enumerated_list = {


### PR DESCRIPTION
Implements: 

`flatten(normal_dict, reducer='underscore')` and `flatten(normal_dict, reducer='underscore')`

as mentioned in #11 

includes tests. 

