### PR TITLE
Use format for underscore option to include type casting

### DIFF
--- a/src/flatten_dict/reducer.py
+++ b/src/flatten_dict/reducer.py
@@ -24,4 +24,4 @@ def underscore_reducer(k1, k2):
     if k1 is None:
         return k2
     else:
-        return k1 + "_" + k2
+        return "{0}_{1}".format(k1, k2)


### PR DESCRIPTION
If underscore_reducer is used in conjunction with list as one of the enumerate types, the current implementation fails. This stems from a missing type conversion of the list indices to strings.