### PR TITLE
Fixed flattening enumerated objects with path reducer

### DIFF
--- a/src/flatten_dict/reducer.py
+++ b/src/flatten_dict/reducer.py
@@ -10,7 +10,7 @@ def path_reducer(k1, k2):
     if k1 is None:
         return k2
     else:
-        return os.path.join(k1, k2)
+        return os.path.join(str(k1), str(k2))
 
 
 def dot_reducer(k1, k2):


### PR DESCRIPTION
Added unconditional string converting to the arguments of the path.join call.
Fixes ianlini/flatten-dict#23