### PR TITLE
add maker functions for reducers and splitters

### DIFF
--- a/src/flatten_dict/reducer.py
+++ b/src/flatten_dict/reducer.py
@@ -25,3 +25,19 @@ def underscore_reducer(k1, k2):
         return k2
     else:
         return "{0}_{1}".format(k1, k2)
+
+
+def make_reducer(delim):
+    """Create a reducer with a custom delimiter.
+
+    :param delim: delimiter to use to join keys.
+    :return: callable: callable that can be passed to ``flatten``'s ``reducer`` argument.
+    """
+
+    def f(k1, k2):
+        if k1 is None:
+            return k2
+        else:
+            return f"{k1}{delim}{k2}"
+
+    return f

--- a/src/flatten_dict/reducer.py
+++ b/src/flatten_dict/reducer.py
@@ -27,10 +27,10 @@ def underscore_reducer(k1, k2):
         return "{0}_{1}".format(k1, k2)
 
 
-def make_reducer(delim):
+def make_reducer(delimiter):
     """Create a reducer with a custom delimiter.
 
-    :param delim: delimiter to use to join keys.
+    :param delimiter: delimiter to use to join keys.
     :return: callable: callable that can be passed to ``flatten``'s ``reducer`` argument.
     """
 
@@ -38,6 +38,6 @@ def make_reducer(delim):
         if k1 is None:
             return k2
         else:
-            return f"{k1}{delim}{k2}"
+            return f"{k1}{delimiter}{k2}"
 
     return f

--- a/src/flatten_dict/reducer.py
+++ b/src/flatten_dict/reducer.py
@@ -30,8 +30,15 @@ def underscore_reducer(k1, k2):
 def make_reducer(delimiter):
     """Create a reducer with a custom delimiter.
 
-    :param delimiter: delimiter to use to join keys.
-    :return: callable: callable that can be passed to ``flatten``'s ``reducer`` argument.
+    Parameters
+    ----------
+    delimiter : str
+        Delimiter to use to join keys.
+
+    Returns
+    -------
+    f : callable
+        Callable that can be passed to `flatten()`'s `reducer` argument.
     """
 
     def f(k1, k2):

--- a/src/flatten_dict/splitter.py
+++ b/src/flatten_dict/splitter.py
@@ -20,13 +20,13 @@ def underscore_splitter(flat_key):
     return keys
 
 
-def make_splitter(delim):
+def make_splitter(delimiter):
     """Create a splitter with a custom delimiter.
 
-    :param delim: delimiter to use to split keys. 
+    :param delimiter: delimiter to use to split keys. 
     :return: callable: callable that can be passed to ``unflatten``'s ``splitter`` argument.
     """
     def f(flat_key):
-        keys = tuple(flat_key.split(delim))
+        keys = tuple(flat_key.split(delimiter))
         return keys
     return f

--- a/src/flatten_dict/splitter.py
+++ b/src/flatten_dict/splitter.py
@@ -18,3 +18,15 @@ def dot_splitter(flat_key):
 def underscore_splitter(flat_key):
     keys = tuple(flat_key.split("_"))
     return keys
+
+
+def make_splitter(delim):
+    """Create a splitter with a custom delimiter.
+
+    :param delim: delimiter to use to split keys. 
+    :return: callable: callable that can be passed to ``unflatten``'s ``splitter`` argument.
+    """
+    def f(flat_key):
+        keys = tuple(flat_key.split(delim))
+        return keys
+    return f

--- a/src/flatten_dict/splitter.py
+++ b/src/flatten_dict/splitter.py
@@ -21,10 +21,17 @@ def underscore_splitter(flat_key):
 
 
 def make_splitter(delimiter):
-    """Create a splitter with a custom delimiter.
+    """Create a reducer with a custom delimiter.
 
-    :param delimiter: delimiter to use to split keys. 
-    :return: callable: callable that can be passed to ``unflatten``'s ``splitter`` argument.
+    Parameters
+    ----------
+    delimiter : str
+        Delimiter to use to split keys.
+
+    Returns
+    -------
+    f : callable
+        Callable that can be passed to ``unflatten``'s ``splitter`` argument.
     """
     def f(flat_key):
         keys = tuple(flat_key.split(delimiter))

--- a/src/flatten_dict/tests/flatten_dict_test.py
+++ b/src/flatten_dict/tests/flatten_dict_test.py
@@ -5,8 +5,8 @@ import six
 import pytest
 
 from flatten_dict import flatten, unflatten
-from flatten_dict.reducer import tuple_reducer, path_reducer, underscore_reducer
-from flatten_dict.splitter import tuple_splitter, path_splitter, underscore_splitter
+from flatten_dict.reducer import tuple_reducer, path_reducer, underscore_reducer, make_reducer, dot_reducer
+from flatten_dict.splitter import tuple_splitter, path_splitter, underscore_splitter, dot_splitter, make_splitter
 
 
 @pytest.fixture
@@ -259,3 +259,32 @@ def test_flatten_dict_with_empty_dict_kept(dict_with_empty_dict, flat_tuple_dict
 
 def test_flatten_dict_with_keep_empty_types(normal_dict, flat_tuple_dict):
     assert flatten(normal_dict, keep_empty_types=(dict, str)) == flat_tuple_dict
+
+
+@pytest.mark.parametrize(
+    "delim, delim_equiv",
+    [
+        (".", "dot"),
+        ("_", "underscore"),
+    ]
+)
+def test_make_reducer(normal_dict, delim, delim_equiv):
+    reducer = make_reducer(delim)
+    flattened_dict_using_make_reducer = flatten(normal_dict, reducer=reducer)
+    flattened_dict_using_equivalent_reducer = flatten(normal_dict, reducer=delim_equiv)
+    assert flattened_dict_using_make_reducer == flattened_dict_using_equivalent_reducer
+
+
+@pytest.mark.parametrize(
+    "delim, delim_equiv",
+    [
+        (".", "dot"),
+        ("_", "underscore")
+    ]
+)
+def test_make_splitter(normal_dict, delim, delim_equiv):
+    splitter = make_splitter(delim)
+    flat_dict = flatten(normal_dict, delim_equiv)
+    unflattened_dict_using_make_splitter = unflatten(flat_dict, splitter=splitter)
+    unflattened_dict_using_equivalent_splitter = unflatten(flat_dict, splitter=delim_equiv)
+    assert unflattened_dict_using_make_splitter == unflattened_dict_using_equivalent_splitter

--- a/src/flatten_dict/tests/flatten_dict_test.py
+++ b/src/flatten_dict/tests/flatten_dict_test.py
@@ -262,29 +262,29 @@ def test_flatten_dict_with_keep_empty_types(normal_dict, flat_tuple_dict):
 
 
 @pytest.mark.parametrize(
-    "delim, delim_equiv",
+    "delimiter, delimiter_equivalent",
     [
         (".", "dot"),
         ("_", "underscore"),
     ]
 )
-def test_make_reducer(normal_dict, delim, delim_equiv):
-    reducer = make_reducer(delim)
+def test_make_reducer(normal_dict, delimiter, delimiter_equivalent):
+    reducer = make_reducer(delimiter)
     flattened_dict_using_make_reducer = flatten(normal_dict, reducer=reducer)
-    flattened_dict_using_equivalent_reducer = flatten(normal_dict, reducer=delim_equiv)
+    flattened_dict_using_equivalent_reducer = flatten(normal_dict, reducer=delimiter_equivalent)
     assert flattened_dict_using_make_reducer == flattened_dict_using_equivalent_reducer
 
 
 @pytest.mark.parametrize(
-    "delim, delim_equiv",
+    "delimiter, delimiter_equivalent",
     [
         (".", "dot"),
         ("_", "underscore")
     ]
 )
-def test_make_splitter(normal_dict, delim, delim_equiv):
-    splitter = make_splitter(delim)
-    flat_dict = flatten(normal_dict, delim_equiv)
+def test_make_splitter(normal_dict, delimiter, delimiter_equivalent):
+    splitter = make_splitter(delimiter)
+    flat_dict = flatten(normal_dict, delimiter_equivalent)
     unflattened_dict_using_make_splitter = unflatten(flat_dict, splitter=splitter)
-    unflattened_dict_using_equivalent_splitter = unflatten(flat_dict, splitter=delim_equiv)
+    unflattened_dict_using_equivalent_splitter = unflatten(flat_dict, splitter=delimiter_equivalent)
     assert unflattened_dict_using_make_splitter == unflattened_dict_using_equivalent_splitter


### PR DESCRIPTION
This PR proposes to add functions that return reducer and splitter functions rather than having to write them out yourself (i.e. for delimiters other than "dot" and "underscore")